### PR TITLE
CHECKOUT-3012: Avoid loading the same script twice

### DIFF
--- a/src/create-script-loader.ts
+++ b/src/create-script-loader.ts
@@ -1,5 +1,5 @@
 import ScriptLoader from './script-loader';
 
 export default function createScriptLoader(): ScriptLoader {
-    return new ScriptLoader(document);
+    return new ScriptLoader();
 }

--- a/src/get-script-loader.spec.ts
+++ b/src/get-script-loader.spec.ts
@@ -1,0 +1,12 @@
+import getScriptLoader from './get-script-loader';
+import ScriptLoader from './script-loader';
+
+describe('getScriptLoader()', () => {
+    it('returns same `ScriptLoader` instance', () => {
+        const loader = getScriptLoader();
+        const loader2 = getScriptLoader();
+
+        expect(loader).toBe(loader2);
+        expect(loader).toBeInstanceOf(ScriptLoader);
+    });
+});

--- a/src/get-script-loader.ts
+++ b/src/get-script-loader.ts
@@ -1,0 +1,12 @@
+import ScriptLoader from './script-loader';
+import createScriptLoader from './create-script-loader';
+
+let instance: ScriptLoader;
+
+export default function getScriptLoader(): ScriptLoader {
+    if (!instance) {
+        instance = createScriptLoader();
+    }
+
+    return instance;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { default as ScriptLoader } from './script-loader';
 export { default as createScriptLoader } from './create-script-loader';
+export { default as getScriptLoader } from './get-script-loader';

--- a/src/script-loader.spec.ts
+++ b/src/script-loader.spec.ts
@@ -12,7 +12,7 @@ describe('ScriptLoader', () => {
             element.onreadystatechange(new Event('readystatechange'))
         );
 
-        loader = new ScriptLoader(document);
+        loader = new ScriptLoader();
     });
 
     afterEach(() => {
@@ -42,5 +42,12 @@ describe('ScriptLoader', () => {
         } catch (output) {
             expect(output).toBeInstanceOf(Event);
         }
+    });
+
+    it('does not load same script twice', async () => {
+        await loader.loadScript('https://code.jquery.com/jquery-3.2.1.min.js');
+        await loader.loadScript('https://code.jquery.com/jquery-3.2.1.min.js');
+
+        expect(document.body.appendChild).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -1,20 +1,22 @@
 export default class ScriptLoader {
-    constructor(
-        private _document: Document
-    ) {}
+    private _scripts: { [key: string]: Promise<Event> } = {};
 
     loadScript(src: string): Promise<Event> {
-        return new Promise((resolve, reject) => {
-            const script = this._document.createElement('script') as LegacyHTMLScriptElement;
+        if (!this._scripts[src]) {
+            this._scripts[src] = new Promise((resolve, reject) => {
+                const script = document.createElement('script') as LegacyHTMLScriptElement;
 
-            script.onload = (event) => resolve(event);
-            script.onreadystatechange = (event) => resolve(event);
-            script.onerror = (event) => reject(event);
-            script.async = true;
-            script.src = src;
+                script.onload = (event) => resolve(event);
+                script.onreadystatechange = (event) => resolve(event);
+                script.onerror = (event) => reject(event);
+                script.async = true;
+                script.src = src;
 
-            this._document.body.appendChild(script);
-        });
+                document.body.appendChild(script);
+            });
+        }
+
+        return this._scripts[src];
     }
 }
 


### PR DESCRIPTION
## What?
* Avoid loading the same script more than once by storing a list of loaded scripts.

## Why?
* Otherwise, you'll inject a new script element each time you call `loadScript`.

## Testing / Proof
* Unit

@bigcommerce/frontend
