### PR TITLE
CHECKOUT-4455: Provide fallback for browsers that don't support `preload` attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,27 @@
         }
       }
     },
+    "@bigcommerce/request-sender": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/request-sender/-/request-sender-0.3.0.tgz",
+      "integrity": "sha512-qILGm+r6JqZ56kGtgxLq/eAHlQXZMxq64nA2mIB7uxp8RpgDupJrpnVKd7uSQSOoHemUsD6UM/sCYWbGprw2lg==",
+      "requires": {
+        "@types/js-cookie": "^2.1.0",
+        "@types/lodash": "^4.14.133",
+        "@types/query-string": "^5.1.0",
+        "js-cookie": "^2.1.4",
+        "lodash": "^4.17.11",
+        "query-string": "^5.0.0",
+        "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
     "@bigcommerce/tslint-config": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@bigcommerce/tslint-config/-/tslint-config-2.0.1.tgz",
@@ -61,6 +82,21 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.10.tgz",
       "integrity": "sha512-qDyqzbcyNgW2RgWbl606xCYQ+5fK9khOW5+Hl3wH7RggVES0dB6GcZvpmPs/XIty5qpu1xYCwpiK+iRkJ3xFBw==",
       "dev": true
+    },
+    "@types/js-cookie": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.2.tgz",
+      "integrity": "sha512-vkuGzldF9mNsWS9cmmMFfW1rufa7IdPUorS150gKoU/2fzLJ/0LXiMMtRqIBWz0sZ/VF2VxwB25WXEOo6akU6w=="
+    },
+    "@types/lodash": {
+      "version": "4.14.141",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.141.tgz",
+      "integrity": "sha512-v5NYIi9qEbFEUpCyikmnOYe4YlP8BMUdTcNCAquAKzu+FA7rZ1onj9x80mbnDdOW/K5bFf3Tv5kJplP33+gAbQ=="
+    },
+    "@types/query-string": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-5.1.0.tgz",
+      "integrity": "sha512-9/sJK+T04pNq7uwReR0CLxqXj1dhxiTapZ1tIxA0trEsT6FRS0bz09YMcMb7tsVBTm4RJ0NEBYGsAjoEmqoFXg=="
     },
     "JSONStream": {
       "version": "1.3.2",
@@ -1704,8 +1740,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3879,6 +3914,11 @@
         "pretty-format": "^21.2.1"
       }
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4523,8 +4563,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -4911,6 +4950,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -5980,6 +6029,11 @@
           }
         }
       }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "validate-commits": "validate-commits"
   },
   "dependencies": {
+    "@bigcommerce/request-sender": "^0.3.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/src/browser-support.spec.ts
+++ b/src/browser-support.spec.ts
@@ -1,0 +1,43 @@
+import BrowserSupport from './browser-support';
+
+describe('BrowserSupport', () => {
+    let link: HTMLLinkElement;
+    let support: BrowserSupport;
+
+    beforeEach(() => {
+        const createElement = document.createElement.bind(document);
+
+        link = {
+            relList: {
+                supports: jest.fn(() => true),
+            },
+        } as unknown as HTMLLinkElement;
+
+        jest.spyOn(document, 'createElement')
+            .mockImplementation(type => {
+                return type === 'link' ? link : createElement(type);
+            });
+
+        support = new BrowserSupport();
+    });
+
+    it('returns true if able to support rel type', () => {
+        expect(support.canSupportRel('preload'))
+            .toEqual(true);
+    });
+
+    it('returns false if unable to support rel type', () => {
+        jest.spyOn(link.relList, 'supports')
+            .mockReturnValue(false);
+
+        expect(support.canSupportRel('preload'))
+            .toEqual(false);
+    });
+
+    it('returns false if `relList` is not supported', () => {
+        link = {} as unknown as HTMLLinkElement;
+
+        expect(support.canSupportRel('preload'))
+            .toEqual(false);
+    });
+});

--- a/src/browser-support.ts
+++ b/src/browser-support.ts
@@ -1,0 +1,11 @@
+export default class BrowserSupport {
+    canSupportRel(rel: string): boolean {
+        const link = document.createElement('link');
+
+        return !!(
+            link.relList &&
+            link.relList.supports &&
+            link.relList.supports(rel)
+        );
+    }
+}

--- a/src/create-script-loader.ts
+++ b/src/create-script-loader.ts
@@ -1,5 +1,11 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import BrowserSupport from './browser-support';
 import ScriptLoader from './script-loader';
 
 export default function createScriptLoader(): ScriptLoader {
-    return new ScriptLoader();
+    return new ScriptLoader(
+        new BrowserSupport(),
+        createRequestSender()
+    );
 }

--- a/src/create-stylesheet-loader.ts
+++ b/src/create-stylesheet-loader.ts
@@ -1,5 +1,11 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import BrowserSupport from './browser-support';
 import StylesheetLoader from './stylesheet-loader';
 
 export default function createStylesheetLoader(): StylesheetLoader {
-    return new StylesheetLoader();
+    return new StylesheetLoader(
+        new BrowserSupport(),
+        createRequestSender()
+    );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-export { default as ScriptLoader } from './script-loader';
+export { default as ScriptLoader, LoadScriptOptions, PreloadScriptOptions } from './script-loader';
 export { default as createScriptLoader } from './create-script-loader';
 export { default as getScriptLoader } from './get-script-loader';
 
-export { default as StylesheetLoader } from './stylesheet-loader';
+export { default as StylesheetLoader, LoadStylesheetOptions, PreloadStylesheetOptions } from './stylesheet-loader';
 export { default as createStylesheetLoader } from './create-stylesheet-loader';
 export { default as getStylesheetLoader } from './get-stylesheet-loader';

--- a/src/script-loader.spec.ts
+++ b/src/script-loader.spec.ts
@@ -64,7 +64,7 @@ describe('ScriptLoader', () => {
             const output = await loader.loadScript('https://code.jquery.com/jquery-3.2.1.min.js');
 
             expect(output)
-                .toBeInstanceOf(Event);
+                .toBeUndefined();
         });
 
         it('does not load same script twice', async () => {
@@ -229,7 +229,7 @@ describe('ScriptLoader', () => {
             const output = await loader.preloadScript('https://cdn.foobar.com/foo.min.js');
 
             expect(output)
-                .toBeInstanceOf(Event);
+                .toBeUndefined();
         });
     });
 });

--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -1,15 +1,32 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import BrowserSupport from './browser-support';
+
+export interface LoadScriptOptions {
+    async: boolean;
+}
+
 export interface PreloadScriptOptions {
     prefetch: boolean;
 }
 
 export default class ScriptLoader {
     private _scripts: { [key: string]: Promise<Event> } = {};
-    private _preloadedScripts: { [key: string]: Promise<Event> } = {};
+    private _preloadedScripts: { [key: string]: Promise<Event | Response> } = {};
 
-    loadScript(src: string): Promise<Event> {
+    /**
+     * @internal
+     */
+    constructor(
+        private _browserSupport: BrowserSupport,
+        private _requestSender: RequestSender
+    ) {}
+
+    loadScript(src: string, options?: LoadScriptOptions): Promise<Event> {
         if (!this._scripts[src]) {
             this._scripts[src] = new Promise((resolve, reject) => {
                 const script = document.createElement('script') as LegacyHTMLScriptElement;
+                const { async = false } = options || {};
 
                 script.onload = event => resolve(event);
                 script.onreadystatechange = event => resolve(event);
@@ -17,7 +34,7 @@ export default class ScriptLoader {
                     delete this._scripts[src];
                     reject(event);
                 };
-                script.async = true;
+                script.async = async;
                 script.src = src;
 
                 document.body.appendChild(script);
@@ -27,58 +44,48 @@ export default class ScriptLoader {
         return this._scripts[src];
     }
 
-    loadScripts(urls: string[]): Promise<Event[]> {
-        const events: Event[] = [];
-        let promise: Promise<Event> | undefined;
-
-        return this.preloadScripts(urls)
-            .then(() => {
-                urls.forEach(url => {
-                    if (promise) {
-                        promise = promise.then(() => this.loadScript(url));
-                    } else {
-                        promise = this.loadScript(url);
-                    }
-
-                    promise = promise.then(event => {
-                        events.push(event);
-
-                        return event;
-                    });
-                });
-
-                return promise;
-            })
-            .then(() => events);
+    loadScripts(urls: string[], options?: LoadScriptOptions): Promise<Event[]> {
+        return Promise.all(urls.map(url => this.loadScript(url, options)));
     }
 
-    preloadScript(url: string, options?: PreloadScriptOptions): Promise<Event> {
+    preloadScript(url: string, options?: PreloadScriptOptions): Promise<Event | Response> {
         if (!this._preloadedScripts[url]) {
             this._preloadedScripts[url] = new Promise((resolve, reject) => {
-                const preloadedScript = document.createElement('link');
                 const { prefetch = false } = options || {};
+                const rel = prefetch ? 'prefetch' : 'preload';
 
-                preloadedScript.as = 'script';
-                preloadedScript.rel = prefetch ? 'prefetch' : 'preload';
-                preloadedScript.href = url;
+                if (this._browserSupport.canSupportRel(rel)) {
+                    const preloadedScript = document.createElement('link');
 
-                preloadedScript.onload = event => {
-                    resolve(event);
-                };
+                    preloadedScript.as = 'script';
+                    preloadedScript.rel = rel;
+                    preloadedScript.href = url;
 
-                preloadedScript.onerror = event => {
-                    delete this._preloadedScripts[url];
-                    reject(event);
-                };
+                    preloadedScript.onload = event => {
+                        resolve(event);
+                    };
 
-                document.head.appendChild(preloadedScript);
+                    preloadedScript.onerror = event => {
+                        delete this._preloadedScripts[url];
+                        reject(event);
+                    };
+
+                    document.head.appendChild(preloadedScript);
+                } else {
+                    this._requestSender.get(url, {
+                        credentials: false,
+                        headers: { Accept: 'application/javascript' },
+                    })
+                        .then(resolve)
+                        .catch(reject);
+                }
             });
         }
 
         return this._preloadedScripts[url];
     }
 
-    preloadScripts(urls: string[], options?: PreloadScriptOptions): Promise<Event[]> {
+    preloadScripts(urls: string[], options?: PreloadScriptOptions): Promise<Array<Event | Response>> {
         return Promise.all(urls.map(url => this.preloadScript(url, options)));
     }
 }

--- a/src/stylesheet-loader.spec.ts
+++ b/src/stylesheet-loader.spec.ts
@@ -55,7 +55,7 @@ describe('StylesheetLoader', () => {
             const output = await loader.loadStylesheet('https://foo.bar/hello-world.css');
 
             expect(output)
-                .toBeInstanceOf(Event);
+                .toBeUndefined();
         });
 
         it('does not load same stylesheet twice', async () => {
@@ -166,7 +166,7 @@ describe('StylesheetLoader', () => {
             const output = await loader.preloadStylesheet('https://foo.bar/hello-world.css');
 
             expect(output)
-                .toBeInstanceOf(Event);
+                .toBeUndefined();
         });
     });
 });


### PR DESCRIPTION
## What?
1. Provide a fallback method for preloading scripts in the background for browsers that don't support `preload` attribute.
1. **Breaking change:** Stop returning event objects when scripts are loaded.

## Why?
1. It seems not all browsers support `prefetch` and `preload`. So for unsupported browsers, we simply load the resources using XHR. If JS / CSS are served with the right cache-control header, they can be retrieved from the browser cache when we actually load them on the page.
1. Previously, when a script is loaded, we return the associated event object inside a promise object to the caller. With this change, we return an empty promise object instead. This change is necessary because we can't guarantee that scripts can be loaded in the same way across different browsers. For example, some browsers don't support `rel="preload"`, so as a fallback, we have to preload scripts using regular XHR calls. In that case, we don't have an event object to return to the caller. We could potentially mock the event object to keep the return values consistent. But considering it is not a very useful thing to return, we've decided to make a breaking change and return nothing instead.

## Testing / Proof
Unit

@bigcommerce/checkout 
