### PR TITLE
fix(common): FP-00 Update typescript config to remove sourcemap generation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,
-        "inlineSources": true,
         "lib": [
             "dom",
             "dom.iterable",
@@ -14,7 +13,6 @@
         "moduleResolution": "node",
         "removeComments": true,
         "skipLibCheck": true,
-        "sourceMap": true,
         "strict": true,
         "stripInternal": true,
         "target": "es5"


### PR DESCRIPTION
## What?
Similar PR than this one https://github.com/bigcommerce/request-sender-js/pull/46

This removes the generation of sourcemaps in the typescript build to let consumer applications build them.

## Why?
This is causing some issues because of the inline sourcemap when building with webpack.
```
ERROR in chunk app [entry]
/node_modules/.pnpm/babel-loader@8.2.3_uwaygiumfr5ruezn5bfsw34234/node_modules/babel-loader/lib/index.js??ref--4-0!/node_modules/.pnpm/@bigcommerce+script-loader@2.2.2_typescript@4.7.3/node_modules/@bigcommerce/script-loader/lib/browser-support.js
No element indexed by 7
```

## Testing / Proof
...

@bigcommerce/frontend @chanceaclark
