### PR TITLE
feat(core): CHECKOUT-10115 Add support for passing crossorigin

### DIFF
--- a/src/script-loader.spec.ts
+++ b/src/script-loader.spec.ts
@@ -256,6 +256,23 @@ describe('ScriptLoader', () => {
                 });
         });
 
+        it('sets crossorigin attribute if option is provided', async () => {
+            await loader.preloadScript('https://cdn.foobar.com/foo.min.js', {
+                prefetch: true,
+                crossOrigin: 'anonymous',
+            });
+
+            expect(preloadedScript.crossOrigin)
+                .toEqual('anonymous');
+        });
+
+        it('does not set crossorigin attribute if option is not provided', async () => {
+            await loader.preloadScript('https://cdn.foobar.com/foo.min.js');
+
+            expect(preloadedScript.crossOrigin)
+                .toBeFalsy();
+        });
+
         it('resolves promise if script is preloaded', async () => {
             const output = await loader.preloadScript('https://cdn.foobar.com/foo.min.js');
 

--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -9,6 +9,7 @@ export interface LoadScriptOptions {
 
 export interface PreloadScriptOptions {
     prefetch: boolean;
+    crossOrigin?: string;
 }
 
 export interface ScriptAttributes {
@@ -62,7 +63,7 @@ export default class ScriptLoader {
     preloadScript(url: string, options?: PreloadScriptOptions): Promise<void> {
         if (!this._preloadedScripts[url]) {
             this._preloadedScripts[url] = new Promise((resolve, reject) => {
-                const { prefetch = false } = options || {};
+                const { prefetch = false, crossOrigin } = options || {};
                 const rel = prefetch ? 'prefetch' : 'preload';
 
                 if (this._browserSupport.canSupportRel(rel)) {
@@ -72,12 +73,20 @@ export default class ScriptLoader {
                     preloadedScript.rel = rel;
                     preloadedScript.href = url;
 
+                    if (crossOrigin) {
+                        preloadedScript.crossOrigin = crossOrigin;
+                    }
+
                     preloadedScript.onload = () => {
                         resolve();
                     };
 
                     preloadedScript.onerror = () => {
                         delete this._preloadedScripts[url];
+
+                        // tslint:disable-next-line:no-console
+                        console.log(`Unable to preload script: ${url}`);
+
                         reject();
                     };
 

--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -9,7 +9,7 @@ export interface LoadScriptOptions {
 
 export interface PreloadScriptOptions {
     prefetch: boolean;
-    crossOrigin?: string;
+    crossOrigin?: 'anonymous' | 'use-credentials';
 }
 
 export interface ScriptAttributes {

--- a/src/stylesheet-loader.spec.ts
+++ b/src/stylesheet-loader.spec.ts
@@ -196,6 +196,23 @@ describe('StylesheetLoader', () => {
                 });
         });
 
+        it('sets crossorigin attribute if option is provided', async () => {
+            await loader.preloadStylesheet('https://foo.bar/hello-world.css', {
+                prefetch: true,
+                crossOrigin: 'anonymous',
+            });
+
+            expect(preloadedStylesheet.crossOrigin)
+                .toEqual('anonymous');
+        });
+
+        it('does not set crossorigin attribute if option is not provided', async () => {
+            await loader.preloadStylesheet('https://foo.bar/hello-world.css');
+
+            expect(preloadedStylesheet.crossOrigin)
+                .toBeFalsy();
+        });
+
         it('resolves promise if stylesheet is preloaded', async () => {
             const output = await loader.preloadStylesheet('https://foo.bar/hello-world.css');
 

--- a/src/stylesheet-loader.ts
+++ b/src/stylesheet-loader.ts
@@ -9,6 +9,7 @@ export interface LoadStylesheetOptions {
 
 export interface PreloadStylesheetOptions {
     prefetch: boolean;
+    crossOrigin?: string;
 }
 
 export interface StylesheetAttributes {
@@ -65,7 +66,7 @@ export default class StylesheetLoader {
     preloadStylesheet(url: string, options?: PreloadStylesheetOptions): Promise<void> {
         if (!this._preloadedStylesheets[url]) {
             this._preloadedStylesheets[url] = new Promise((resolve, reject) => {
-                const { prefetch = false } = options || {};
+                const { prefetch = false, crossOrigin } = options || {};
                 const rel = prefetch ? 'prefetch' : 'preload';
 
                 if (this._browserSupport.canSupportRel(rel)) {
@@ -75,12 +76,20 @@ export default class StylesheetLoader {
                     preloadedStylesheet.rel = prefetch ? 'prefetch' : 'preload';
                     preloadedStylesheet.href = url;
 
+                    if (crossOrigin) {
+                        preloadedStylesheet.crossOrigin = crossOrigin;
+                    }
+
                     preloadedStylesheet.onload = () => {
                         resolve();
                     };
 
                     preloadedStylesheet.onerror = event => {
                         delete this._preloadedStylesheets[url];
+
+                        // tslint:disable-next-line:no-console
+                        console.log(`Unable to preload stylesheet: ${url}`);
+
                         reject(event);
                     };
 

--- a/src/stylesheet-loader.ts
+++ b/src/stylesheet-loader.ts
@@ -9,7 +9,7 @@ export interface LoadStylesheetOptions {
 
 export interface PreloadStylesheetOptions {
     prefetch: boolean;
-    crossOrigin?: string;
+    crossOrigin?: 'anonymous' | 'use-credentials';
 }
 
 export interface StylesheetAttributes {


### PR DESCRIPTION
## What?

Adds a crossOrigin option to `preloadScript` / `preloadStylesheet`, applied to the generated `<link rel="preload|prefetch">` tag. Also logs a `console.log` message identifying the URL when a preload link fails to load. The rejection behavior itself is unchanged (scripts still reject with no payload, stylesheets with the raw event), so existing consumers see no difference in rejection shape.

## Why?
Needed for https://github.com/bigcommerce/checkout-js/pull/3168. checkout-js prefetches its checkout-step chunks through this library, but the generated links have no `crossorigin` attribute, while the real chunk loads use `crossorigin="anonymous"` + SRI. Passing crossOrigin: 'anonymous' makes the prefetch request mode match the real load, so the cached response is valid and reused.

## Testing / Proof
Unit tests: 4 new specs (crossorigin attribute set / not set for both loaders); full suite all passing, tslint + tsc --noEmit clean.

@bigcommerce/frontend
